### PR TITLE
✨ feat: 로그인 계정 정보를 외부에서 가져온다

### DIFF
--- a/lotto/account.py
+++ b/lotto/account.py
@@ -1,0 +1,39 @@
+from argparse import ArgumentParser
+from typing import Optional
+
+import keyring
+
+ID_ARGUMENT_NAME = '--id'
+ID_ARGUMENT_OPTIONS = {'type': str, 'help': '로또 사이트 계정 아이디'}
+KEYRING_SERVICE_NAME = 'lotto-purchase-keyring'
+
+
+def account() -> tuple[str, Optional[str]]:
+    _id = _id_from_args()
+    return _id, _password_from_keyring(_id)
+
+
+def _id_from_args() -> str:
+    parser = ArgumentParser()
+    parser.add_argument(ID_ARGUMENT_NAME, **ID_ARGUMENT_OPTIONS)
+    known_args = parser.parse_known_args()[0]
+    return known_args.id
+
+
+def _password_from_keyring(account_id: str) -> Optional[str]:
+    """ 최초 1회 [system keyring service]에 계정을 등록해야 함.
+
+    등록 방법:
+        코드 사용 (등록 후 제거할 것)
+        > keyring.set_password(`KEYRING_SERVICE_NAME`, 'id', 'password')
+
+        커맨드 라인 사용
+        $ keyring set `KEYRING_SERVICE_NAME` 'id'
+
+    주의:
+        이 작업은 현재 등록하는 계정 정보에 python 접근을 허용함.
+
+    기타:
+        macOS key chain 사용은 macOS 11, python 3.8.7 이상을 필요로 함.
+    """
+    return keyring.get_password(KEYRING_SERVICE_NAME, account_id)

--- a/main.py
+++ b/main.py
@@ -1,3 +1,4 @@
+from lotto.account import account
 from lotto.lotto import go_login, login_input_boxs, login_button, alert, go_lotto, layer_popup, amount_select, \
     auto_checkbox, apply_button, buy_button, confirm_button
 
@@ -10,6 +11,8 @@ class LottoError(Exception):
 # todo: 클라이언트에서 send_keys 사용성
 # todo: 로그인 성공/실패 기준 어떤걸로?
 def login(_id: str, password: str) -> None:
+    assert _id and password
+
     go_login()
     _id_box, password_box = login_input_boxs()
 
@@ -47,10 +50,5 @@ def buy(amount: int) -> None:
 
 
 if __name__ == '__main__':
-    # todo: 개인정보인데 어떻게 관리?
-    _id = 'my_id'
-    _password = 'my_password'
-
-    # 시작
-    login(_id, _password)
+    login(*account())
     buy(amount=5)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,12 @@ certifi==2022.12.7
 exceptiongroup==1.1.0
 h11==0.14.0
 idna==3.4
+importlib-metadata==6.0.0
 iniconfig==2.0.0
+jaraco.classes==3.2.3
+keyring==23.13.1
+login==0.0.6
+more-itertools==9.0.0
 outcome==1.2.0
 packaging==23.0
 pluggy==1.0.0
@@ -18,3 +23,4 @@ trio==0.22.0
 trio-websocket==0.9.2
 urllib3==1.26.14
 wsproto==1.2.0
+zipp==3.12.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,14 @@
+from typing import Optional
+
+import pytest
 from _pytest.config.argparsing import Parser
 
 from lotto import account as lotto_account
+
+
+@pytest.fixture(scope='module')
+def account() -> tuple[str, Optional[str]]:
+    return lotto_account.account()
 
 
 def pytest_addoption(parser):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+from _pytest.config.argparsing import Parser
+
+from lotto import account as lotto_account
+
+
+def pytest_addoption(parser):
+    _add_id_option_for_passing_argument_to_pytest(parser)
+
+
+def _add_id_option_for_passing_argument_to_pytest(parser: Parser):
+    parser.addoption(lotto_account.ID_ARGUMENT_NAME,
+                     **lotto_account.ID_ARGUMENT_OPTIONS)

--- a/tests/test_lotto.py
+++ b/tests/test_lotto.py
@@ -23,8 +23,8 @@ def test_login_button():
     assert button.accessible_name == '로그인'
 
 
-def test_amount_select():
-    login('my_id', 'my_password')  # todo
+def test_amount_select(account):
+    login(*account)  # todo
     go_lotto()
 
     select = amount_select()
@@ -33,8 +33,8 @@ def test_amount_select():
     assert len(select.options) == 5
 
 
-def test_auto_checkbox():
-    login('my_id', 'my_password')  # todo
+def test_auto_checkbox(account):
+    login(*account)  # todo
     go_lotto()
 
     checkbox = auto_checkbox()
@@ -42,23 +42,23 @@ def test_auto_checkbox():
     assert not checkbox.is_selected()
 
 
-def test_apply_button():
-    login('my_id', 'my_password')  # todo
+def test_apply_button(account):
+    login(*account)  # todo
     go_lotto()
 
     assert apply_button()
 
 
-def test_buy_button():
-    login('my_id', 'my_password')  # todo
+def test_buy_button(account):
+    login(*account)  # todo
     go_lotto()
 
     assert buy_button()
 
 
 # todo
-def test_confirm_button():
-    login('my_id', 'my_password')  # todo
+def test_confirm_button(account):
+    login(*account)  # todo
     go_lotto()
     auto_checkbox().click()
     apply_button().click()
@@ -70,8 +70,8 @@ def test_confirm_button():
     assert confirm.is_displayed()
 
 
-def test_total_price():
-    login('my_id', 'my_password')  # todo
+def test_total_price(account):
+    login(*account)  # todo
     go_lotto()
 
     assert total_price() == 0

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -9,8 +9,9 @@ def test_login_success():
     pass
 
 
-def test_buy():
-    login('my_id', 'my_password')  # todo
+# todo: 테스트 lotto로 이동하거나 제거
+def test_buy(account):
+    login(*account)  # todo
     go_lotto()
     buy(amount=5)
     assert total_price() == 5 * 1000


### PR DESCRIPTION
closes #5 


## 목표

- 소스 코드에 하드코딩 된 계정 정보를 외부에서 가져온다


## 작업

- 계정 아이디 - 커맨드라인에서 argument로 입력 받는다
- 계정 비밀번호 - [keyring](https://github.com/jaraco/keyring) 라이브러리를 사용해서 `key chain`을 통해 가져온다(macOS 기준)


## 실행 방법

- 이하 venv 구성 기준으로 작성됨

```bash

# venv 환경 활성화
$ source venv/bin/activate

# ✅ 최초 1회만 설정
# 예시: keyring set lotto-purchase-keyring ElonReeveMusk
$ keyring set <KEYRING_SERVICE_NAME> <로그인할_계정_아이디>

# 프로젝트 실행
# 예시: python main.py --id=ElonReeveMusk
$ python main.py <ID_ARGUMENT_NAME>=<로그인할_계정_아이디>

# venv 환경 비활성화
$ deactivate
```

https://github.com/viiviii/jubilant-train/blob/9200ef767cd08394eb55ecf1e844b84508a07f9e/lotto/account.py#L8

https://github.com/viiviii/jubilant-train/blob/9200ef767cd08394eb55ecf1e844b84508a07f9e/lotto/account.py#L6


## keyring에 대하여

- macOS의 `Keychain`을 사용하기 위해 해당 라이브러리를 선택함
- 윈도우 환경에서는 `Credential Locker`를 사용한다는데 테스트해보지 않았음

