### PR TITLE
✨ feat: 계정의 비밀번호는 마스킹되어 보여진다

### DIFF
--- a/lotto/account.py
+++ b/lotto/account.py
@@ -8,9 +8,25 @@ ID_ARGUMENT_OPTIONS = {'type': str, 'help': '로또 사이트 계정 아이디'}
 KEYRING_SERVICE_NAME = 'lotto-purchase-keyring'
 
 
-def account() -> tuple[str, Optional[str]]:
+class Account(object):
+    def __init__(self, account_id: str, account_password: str) -> None:
+        self.id = account_id
+        self.password = account_password
+
+    def __str__(self) -> str:
+        def mask(string) -> str:
+            return '*' * len(string)
+
+        return f'id={self.id}, ' \
+               f'password={mask(self.password) if self.password else self.password}'
+
+    def __repr__(self) -> str:
+        return f'Account({self})'
+
+
+def fetch_account() -> Account:
     _id = _id_from_args()
-    return _id, _password_from_keyring(_id)
+    return Account(_id, _password_from_keyring(_id))
 
 
 def _id_from_args() -> str:

--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-from lotto.account import account
+from lotto.account import Account, fetch_account
 from lotto.lotto import go_login, login_input_boxs, login_button, alert, go_lotto, layer_popup, amount_select, \
     auto_checkbox, apply_button, buy_button, confirm_button
 
@@ -10,14 +10,14 @@ class LottoError(Exception):
 
 # todo: 클라이언트에서 send_keys 사용성
 # todo: 로그인 성공/실패 기준 어떤걸로?
-def login(_id: str, password: str) -> None:
-    assert _id and password
+def login(account: Account) -> None:
+    assert account
 
     go_login()
     _id_box, password_box = login_input_boxs()
 
-    _id_box.send_keys(_id)
-    password_box.send_keys(password)
+    _id_box.send_keys(account.id)
+    password_box.send_keys(account.password)
 
     login_button().click()
 
@@ -50,5 +50,5 @@ def buy(amount: int) -> None:
 
 
 if __name__ == '__main__':
-    login(*account())
+    login(fetch_account())
     buy(amount=5)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,13 @@
-from typing import Optional
-
 import pytest
 from _pytest.config.argparsing import Parser
 
 from lotto import account as lotto_account
+from lotto.account import Account, fetch_account
 
 
 @pytest.fixture(scope='module')
-def account() -> tuple[str, Optional[str]]:
-    return lotto_account.account()
+def account() -> Account:
+    return fetch_account()
 
 
 def pytest_addoption(parser):

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -1,0 +1,7 @@
+from lotto.account import Account
+
+
+def test_masked_password_when_account_is_print():
+    account = Account('user-id', 'secret0000')
+    assert 'secret0000' not in str(account)
+    assert 'secret0000' not in repr(account)

--- a/tests/test_lotto.py
+++ b/tests/test_lotto.py
@@ -24,7 +24,7 @@ def test_login_button():
 
 
 def test_amount_select(account):
-    login(*account)  # todo
+    login(account)  # todo
     go_lotto()
 
     select = amount_select()
@@ -34,7 +34,7 @@ def test_amount_select(account):
 
 
 def test_auto_checkbox(account):
-    login(*account)  # todo
+    login(account)  # todo
     go_lotto()
 
     checkbox = auto_checkbox()
@@ -43,14 +43,14 @@ def test_auto_checkbox(account):
 
 
 def test_apply_button(account):
-    login(*account)  # todo
+    login(account)  # todo
     go_lotto()
 
     assert apply_button()
 
 
 def test_buy_button(account):
-    login(*account)  # todo
+    login(account)  # todo
     go_lotto()
 
     assert buy_button()
@@ -58,7 +58,7 @@ def test_buy_button(account):
 
 # todo
 def test_confirm_button(account):
-    login(*account)  # todo
+    login(account)  # todo
     go_lotto()
     auto_checkbox().click()
     apply_button().click()
@@ -71,7 +71,7 @@ def test_confirm_button(account):
 
 
 def test_total_price(account):
-    login(*account)  # todo
+    login(account)  # todo
     go_lotto()
 
     assert total_price() == 0

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,6 @@
 import pytest
 
+from lotto.account import Account
 from lotto.lotto import go_lotto, total_price
 from main import login, LottoError, buy
 
@@ -11,15 +12,16 @@ def test_login_success():
 
 # todo: 테스트 lotto로 이동하거나 제거
 def test_buy(account):
-    login(*account)  # todo
+    login(account)  # todo
     go_lotto()
     buy(amount=5)
     assert total_price() == 5 * 1000
 
 
-def test_login_failure_when_wrong_login_info():
+def test_login_failure_when_invalid_account():
     with pytest.raises(LottoError, match='[로그인 실패] *'):
-        login('wrong125id2541', 'wrong@password')
+        invalid_account = Account('invalid125id2541', 'invalid@password')
+        login(invalid_account)
 
 
 def test_buy_failure_when_not_logged_in():


### PR DESCRIPTION
resolves #7 

## 목표

- 계정 정보가 로그에 출력될 때 비밀번호는 마스킹 처리한다


## 고민한 부분

- 찾아본 방법
  1. toString을 override 하는 방법
  2. pytest의 로그 레벨에서의 설정

- 방법(1) 선택 이유
  - pytest에서 몇 가지 우회하는 방법이 있었으나 코드가 너무 복잡하고 현재 프로젝트 규모에 비해 과다하다고 판단
  - [pytest issue](https://github.com/pytest-dev/pytest/issues/8613)에도 나와 같은 사람이 있었는데 다른 사람들의 내용을 보고 납득됐음
    - 해당 기능은 pytest 책임이 아니다
    - 다양한 실행 환경이 존재함에 따라 데이터가 안정적으로 보호되지 않을 가능성이 있다
    - 이것은 파이썬에서 secret value를 관리하는 방법에 더 가깝다


## 알게 된 것

- 파이썬은 `__str__`과 `__repr__` 두 가지 속성이 있다
  - `__str__`은 해당 값을 문자열로 치환하는 느낌이고 `First -> 1`
  - `__repr__`는 객체를 문자열로 어떻게 표현할지에 관한 것 같다 `First -> First(value=1)`
- 난 자바에서 `toString()`을 `__repr__`처럼 사용하지만 종종 값 객체에선 `__str__`처럼 쓰고싶다는 생각을 했었는데 좋은 것 같음