### PR TITLE
✅ test: 테스트가 메서드 실행 순서에 의존적이게 변경한다

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ from lotto import account as lotto_account
 from lotto.account import Account, fetch_account
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='session')
 def account() -> Account:
     return fetch_account()
 

--- a/tests/test_lotto.py
+++ b/tests/test_lotto.py
@@ -1,77 +1,53 @@
+import pytest
+
 from lotto.lotto import *
 from main import login
 
 
-def test_go_login():
-    go_login()
-    assert '동행복권' in title()
-    assert '로그인' in title()
+class TestLoginPage:
+
+    @pytest.fixture(scope='class', autouse=True)
+    def setup(self):
+        go_login()
+
+    def test_title(self):
+        page_title = title()
+        assert '동행복권' in page_title
+        assert '로그인' in page_title
+
+    def test_login_input_boxs(self):
+        boxs = login_input_boxs()
+        assert len(boxs) == 2
+        assert boxs[0].accessible_name == '아이디'
+        assert boxs[1].accessible_name == '비밀번호'
+
+    def test_login_button(self):
+        button = login_button()
+        assert button
+        assert button.accessible_name == '로그인'
 
 
-def test_login_input_boxs():
-    go_login()
-    boxs = login_input_boxs()
-    assert len(boxs) == 2
-    assert boxs[0].accessible_name == '아이디'
-    assert boxs[1].accessible_name == '비밀번호'
+class TestLottoPage:
 
+    @pytest.fixture(scope='class', autouse=True)
+    def setup(self, account):
+        go_login()
+        login(account)
+        go_lotto()
 
-def test_login_button():
-    go_login()
-    button = login_button()
-    assert button
-    assert button.accessible_name == '로그인'
+    def test_auto_checkbox(self):
+        assert auto_checkbox()
 
+    def test_amount_select(self):
+        select = amount_select()
+        assert select
+        assert len(select.options) == 5
 
-def test_amount_select(account):
-    login(account)  # todo
-    go_lotto()
+    def test_apply_button(self):
+        assert apply_button()
 
-    select = amount_select()
+    def test_buy_button(self):
+        assert buy_button()
 
-    assert select
-    assert len(select.options) == 5
-
-
-def test_auto_checkbox(account):
-    login(account)  # todo
-    go_lotto()
-
-    checkbox = auto_checkbox()
-    assert checkbox
-    assert not checkbox.is_selected()
-
-
-def test_apply_button(account):
-    login(account)  # todo
-    go_lotto()
-
-    assert apply_button()
-
-
-def test_buy_button(account):
-    login(account)  # todo
-    go_lotto()
-
-    assert buy_button()
-
-
-# todo
-def test_confirm_button(account):
-    login(account)  # todo
-    go_lotto()
-    auto_checkbox().click()
-    apply_button().click()
-    buy_button().click()
-
-    confirm = confirm_button()
-
-    assert confirm
-    assert confirm.is_displayed()
-
-
-def test_total_price(account):
-    login(account)  # todo
-    go_lotto()
-
-    assert total_price() == 0
+    def test_confirm_button(self):
+        assert confirm_button()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,28 +2,31 @@ import pytest
 
 from lotto.account import Account
 from lotto.lotto import go_lotto, total_price
-from main import login, LottoError, buy
+from main import login, buy, LottoError
 
 
-def test_login_success():
-    # todo: 개인정보인데 어떻게 테스트 작성?
-    pass
+class TestSuccess:
+
+    def test_login(self, account):
+        login(account)  # todo
+        # todo: 로그인 유무 어떻게 체크?
+
+    # todo: 테스트 돌릴 때마다 진짜 살거니?
+    # todo: 진짜 살거면 설정 추가하거나 buy, select로 기능 나누기
+    def test_buy(self):
+        go_lotto()
+        buy(amount=5)
+        assert total_price() == 5 * 1000
 
 
-# todo: 테스트 lotto로 이동하거나 제거
-def test_buy(account):
-    login(account)  # todo
-    go_lotto()
-    buy(amount=5)
-    assert total_price() == 5 * 1000
+# todo: 아 여긴 진짜 격리해야겠다
+class TestFailure:
+    
+    def test_login_failure_when_invalid_account(self):
+        with pytest.raises(LottoError, match='[로그인 실패] *'):
+            invalid_account = Account('invalid125id', 'invalid@password')
+            login(invalid_account)
 
-
-def test_login_failure_when_invalid_account():
-    with pytest.raises(LottoError, match='[로그인 실패] *'):
-        invalid_account = Account('invalid125id2541', 'invalid@password')
-        login(invalid_account)
-
-
-def test_buy_failure_when_not_logged_in():
-    with pytest.raises(LottoError, match='[로또 구매 실패] *'):
-        buy(amount=1)
+    def test_buy_failure_when_not_logged_in(self):
+        with pytest.raises(LottoError, match='[로또 구매 실패] *'):
+            buy(amount=1)


### PR DESCRIPTION
## 관련 이슈

#11 


## 목표

- 테스트가 격리되지 않아 테스트가 실패하는 것을 성공시킨다


## 작업

### 공통
- 관련된 테스트들을 class로 묶어 가독성을 높인다
- todo: 추후 driver open, close가 추가되면 이 클래스 단위를 기준으로 테스트를 격리시킨다

### test_main.py
- 정말 통합 테스트라 테스트 실행 순서에 의존한다

### test_lotto.py
- 최초 1회 페이지 준비 세팅만 하고 속성이 있는지 확인만 해서 순서에 의존하지 않게 했다


## 특이사항

- pytest는 테스트 메서드 명을 따른다는 검색 결과가 많았는데 나는 테스트 메서드 순서대로 실행됐다(v7.2.1)

