### PR TITLE
✨ feat: github issue에 조회 결과를 전송한다

### DIFF
--- a/lotto/secret.py
+++ b/lotto/secret.py
@@ -1,0 +1,17 @@
+class Secret:
+
+    def __init__(self, value: str):
+        self._value = value
+
+    def __str__(self) -> str:
+        return '*' * len(self._value) if self._value else ''
+
+    def __repr__(self) -> str:
+        return f'Secret({self})'
+
+    def __eq__(self, o: object) -> bool:
+        return self._value == o
+
+    @property
+    def value(self):
+        return self._value

--- a/main.py
+++ b/main.py
@@ -4,6 +4,9 @@ from typing import Any
 
 from lotto.account import Account, fetch_account
 from lotto.lotto import *
+from lotto.secret import Secret
+from sends.send import Send
+from sends.send_github_issue import SendGithubIssue
 
 
 class LottoError(Exception):
@@ -80,6 +83,11 @@ def last_sunday(today: date) -> date:
 
 if __name__ == '__main__':
     login(fetch_account())
-    buy(amount=1)
-    result = check_lottery_result(start_date=last_sunday(date.today()), end_date=date.today())
-    print(to_message(result))
+    # buy(amount=1)
+    lottery_result = check_lottery_result(start_date=last_sunday(date.today()), end_date=date.today())
+    send: Send = SendGithubIssue(
+        token=Secret('ghp_'),
+        repository='viiviii/jubilant-train'
+    )
+    send(title='🎊 로또6/45 1055회(23-02-18)',  # todo: title 하드 코딩 제거
+         content=to_message(lottery_result))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 async-generator==1.10
 attrs==22.2.0
 certifi==2022.12.7
+charset-normalizer==3.0.1
 exceptiongroup==1.1.0
 h11==0.14.0
 idna==3.4
@@ -15,6 +16,7 @@ packaging==23.0
 pluggy==1.0.0
 PySocks==1.7.1
 pytest==7.2.1
+requests==2.28.2
 selenium==4.8.0
 sniffio==1.3.0
 sortedcontainers==2.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,9 @@ pluggy==1.0.0
 PySocks==1.7.1
 pytest==7.2.1
 requests==2.28.2
+requests-mock==1.10.0
 selenium==4.8.0
+six==1.16.0
 sniffio==1.3.0
 sortedcontainers==2.4.0
 tomli==2.0.1

--- a/sends/send.py
+++ b/sends/send.py
@@ -1,0 +1,20 @@
+from abc import ABCMeta, abstractmethod
+from dataclasses import dataclass
+
+
+class SendError(Exception):
+    def __init__(self, reason: str, detail: str):
+        super().__init__(f'[{reason}] {detail}')
+
+
+@dataclass(frozen=True)
+class SendResult:
+    title: str
+    content: str
+
+
+class Send(metaclass=ABCMeta):
+
+    @abstractmethod
+    def __call__(self, title: str, content: str) -> SendResult:
+        pass

--- a/sends/send_github_issue.py
+++ b/sends/send_github_issue.py
@@ -1,0 +1,37 @@
+import requests
+
+from lotto.secret import Secret
+from sends.send import Send, SendResult, SendError
+
+
+class SendGithubIssue(Send):
+
+    def __init__(self, token: Secret, repository: str) -> None:
+        self.token = token
+        self.repository = repository
+
+    def __call__(self, title: str, content: str) -> SendResult:
+        response = self._create_issue(title, content)
+        json = response.json()
+
+        if not response.ok:
+            raise SendError(reason='이슈 생성 실패', detail=json['message'])
+
+        return SendResult(title=json['title'], content=json['body'])
+
+    def _create_issue(self, title: str, content: str) -> requests.Response:
+        """
+        https://docs.github.com/ko/rest/issues/issues?apiVersion=2022-11-28#create-an-issue
+        """
+        return requests.post(
+            f'https://api.github.com/repos/{self.repository}/issues',
+            headers={
+                'Accept': 'application/vnd.github+json',
+                'Authorization': f'Bearer {self.token.value}',
+                'X-GitHub-Api-Version': '2022-11-28',
+            },
+            json={
+                'title': title,
+                'body': content,
+            },
+        )

--- a/tests/test_secret.py
+++ b/tests/test_secret.py
@@ -1,0 +1,28 @@
+import pytest
+
+from lotto.secret import Secret
+
+
+@pytest.mark.parametrize(
+    'original, expected',
+    [(None, None), ('', ''), ('abc', 'abc')]
+)
+def test_value(original, expected):
+    assert Secret(original).value == expected
+
+
+@pytest.mark.parametrize(
+    'original, expected',
+    [(None, ''), ('', ''), ('abc', '***')]
+)
+def test_str(original, expected):
+    assert str(Secret(original)) == expected
+
+
+def test_repr():
+    assert '***********' in repr(Secret('my-password'))
+    assert 'my-password' not in repr(Secret('my-password'))
+
+
+def test_eq():
+    assert Secret('secret1234') == 'secret1234'

--- a/tests/test_send_github_issue.py
+++ b/tests/test_send_github_issue.py
@@ -1,0 +1,32 @@
+import pytest
+
+from lotto.secret import Secret
+from sends.send import SendError
+from sends.send_github_issue import SendGithubIssue
+
+_title = '🎊 로또6/45 1055회(23-02-18)'
+_content = (
+    '💰 총 당첨금: 1,234,567원\n'
+    '✅ 총 구입매수: 5장\n'
+    '📅 조회기간: 23-02-12 ~ 23-02-18')
+
+
+class TestSendGithubIssue:
+
+    def test_success_with_mock(self, requests_mock):
+        requests_mock.post(
+            'https://api.github.com/repos/octocat/Hello-World/issues',
+            json={'title': _title, 'body': _content, }
+        )
+
+        send = SendGithubIssue(token=Secret('mock'), repository='octocat/Hello-World')
+        actual = send(title=_title, content=_content)
+
+        assert actual.title == _title
+        assert actual.content == _content
+
+    def test_failure(self):
+        send = SendGithubIssue(token=Secret('invalid'), repository='octocat/Hello-World')
+
+        with pytest.raises(SendError, match='이슈 생성 실패'):
+            send(title=_title, content=_content)


### PR DESCRIPTION
Closes #15 

## 목표

- 조회 결과를 담은 github issue를 생성한다


## 고민한 부분

- 최초 프로젝트 목적
  - 1일 1커밋 성공 시 local에서 git hooks을 이용하여 구매 이벤트를 발생시키려고 했음
  - 그래서 local에서 실행될 것이라 가정하고 비밀번호도 keyring에서 가져오게 구현함
    - (#6 )
- 발생 문제 
  - 일일 커밋 카운트를 반환하는 Github API가 있을거라 생각했는데 없었음
    - 깃 잔디를 사용한 프로젝트를 둘러본 결과 프로필에서 카운트를 스크래핑 하는 방법과
    - API를 통해 최근 활동 날짜를 체크하는 방법이 있었음
  - 그리고 커밋 할때마다 API를 날려야 됨(fact. 내가 개발 잘 안해서 이건 상관 없긴 함ㅎ) 
- 변경
  - ~귀찮아져서~ git actions를 사용하여 구매(평일), 결과전송(토요일11시)로 변경하기로 함

## 남은 작업

- 현재 최종 조회 결과에 복권 유형과 회차 정보가 없어서 타이틀이 하드코딩 된 부분 수정
- 이제 진짜 리팩토링 할 때가 됐음
- git actions yml 파일 추가하기
- 테스트로 등록된 issue를 보니 결과 메세지 별로임 #16 