### PR TITLE
👷ci: git actions에 테스트를 추가한다

### DIFF
--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -1,0 +1,39 @@
+name: 🔐 Functional test
+
+on: workflow_dispatch
+
+jobs:
+  test:
+    runs-on: macos-latest
+
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Setup Chromedriver for Selenium
+        uses: nanasess/setup-chromedriver@v1
+
+      - name: Run tests
+        env:
+          # Github 기본 환경 변수
+          SEND_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SEND_GITHUB_OWNER: ${{ github.repository_owner }}
+          SEND_GITHUB_REPOSITORY: ${{ github.repository }}
+          # 설정이 필요한 환경 변수
+          LOTTERY_ACCOUNT_ID: ${{ secrets.LOTTERY_ACCOUNT_ID }}
+          LOTTERY_ACCOUNT_PASSWORD: ${{ secrets.LOTTERY_ACCOUNT_PASSWORD }}
+        run: pytest tests/functional

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,43 @@
+name: Tests without buy
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: macos-latest
+
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Setup Chromedriver for Selenium
+        uses: nanasess/setup-chromedriver@v1
+
+      - name: Run tests
+        env:
+          # Github 기본 환경 변수
+          SEND_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SEND_GITHUB_OWNER: ${{ github.repository_owner }}
+          SEND_GITHUB_REPOSITORY: ${{ github.repository }}
+          # 설정이 필요한 환경 변수
+          LOTTERY_ACCOUNT_ID: ${{ secrets.LOTTERY_ACCOUNT_ID }}
+          LOTTERY_ACCOUNT_PASSWORD: ${{ secrets.LOTTERY_ACCOUNT_PASSWORD }}
+        run: pytest -m "not buy_required"

--- a/check_lotto_result/check_latest_lotto_result.py
+++ b/check_lotto_result/check_latest_lotto_result.py
@@ -4,13 +4,13 @@ from selenium import webdriver
 
 from check_lotto_result import message
 from check_lotto_result.summary import group_by_round
-from lotto.account import fetch_account, Account
+from lotto.account import Account, from_env as account_from_env
 from lotto.lotto import Lotto
-from lotto.secret import Secret
 from lotto.site.site import Site
 from lotto.types import DateRange
+from sends.auth import from_env as auth_from_env
+from sends.github import Issue as SendGithubIssue
 from sends.send import Send, SendResult
-from sends.send_github_issue import SendGithubIssue
 
 
 def last_sunday(today: date) -> date:
@@ -31,8 +31,8 @@ def check_latest_lotto_result(account: Account, lotto: Lotto, send: Send, search
 
 if __name__ == '__main__':
     check_latest_lotto_result(
-        account=fetch_account(),
+        account=account_from_env(),
         lotto=Site(driver=webdriver.Chrome()),
-        send=SendGithubIssue(token=Secret('ghp_'), repository='viiviii/jubilant-train'),  # todo: 하드코딩
+        send=SendGithubIssue(auth=auth_from_env()),
         search_dates=DateRange(start=last_sunday(date.today()), end=date.today())
     )

--- a/check_lotto_result/check_latest_lotto_result.py
+++ b/check_lotto_result/check_latest_lotto_result.py
@@ -1,11 +1,10 @@
 from datetime import date, timedelta
 
-from selenium import webdriver
-
 from check_lotto_result import message
 from check_lotto_result.summary import group_by_round
 from lotto.account import Account, from_env as account_from_env
 from lotto.lotto import Lotto
+from lotto.site.drivers import headless_chrome
 from lotto.site.site import Site
 from lotto.types import DateRange
 from sends.auth import from_env as auth_from_env
@@ -32,7 +31,7 @@ def check_latest_lotto_result(account: Account, lotto: Lotto, send: Send, search
 if __name__ == '__main__':
     check_latest_lotto_result(
         account=account_from_env(),
-        lotto=Site(driver=webdriver.Chrome()),
+        lotto=Site(driver=headless_chrome()),
         send=SendGithubIssue(auth=auth_from_env()),
         search_dates=DateRange(start=last_sunday(date.today()), end=date.today())
     )

--- a/lotto/account.py
+++ b/lotto/account.py
@@ -1,3 +1,4 @@
+import os
 from argparse import ArgumentParser
 from typing import Optional
 
@@ -6,14 +7,13 @@ import keyring
 from lotto.secret import Secret
 
 
-class Account(object):
-    def __init__(self, account_id: str, password: str) -> None:
-        self._id = account_id
+class Account:
+    def __init__(self, id_: str, password: str) -> None:
+        self._id = id_
         self._secret = Secret(password)
 
-        if not account_id or not password:
-            raise ValueError('아이디와 비밀번호는 필수 값이다. '
-                             f'id={self.id}, password={self._secret}')
+        if not id_ or not password:
+            raise ValueError(f'계정 정보는 필수 값 입니다. {self.__repr__()}')
 
     @property
     def id(self):
@@ -28,6 +28,13 @@ class Account(object):
 
     def __repr__(self) -> str:
         return f'Account({self})'
+
+
+def from_env() -> Account:
+    return Account(
+        id_=os.environ['LOTTERY_ACCOUNT_ID'],
+        password=os.environ['LOTTERY_ACCOUNT_PASSWORD']
+    )
 
 
 ID_ARGUMENT_NAME = '--id'

--- a/lotto/account.py
+++ b/lotto/account.py
@@ -1,8 +1,4 @@
 import os
-from argparse import ArgumentParser
-from typing import Optional
-
-import keyring
 
 from lotto.secret import Secret
 
@@ -35,39 +31,3 @@ def from_env() -> Account:
         id_=os.environ['LOTTERY_ACCOUNT_ID'],
         password=os.environ['LOTTERY_ACCOUNT_PASSWORD']
     )
-
-
-ID_ARGUMENT_NAME = '--id'
-ID_ARGUMENT_OPTIONS = {'type': str, 'help': '로또 사이트 계정 아이디'}
-KEYRING_SERVICE_NAME = 'lotto-purchase-keyring'
-
-
-def fetch_account() -> Account:
-    _id = _id_from_args()
-    return Account(_id, _password_from_keyring(_id))
-
-
-def _id_from_args() -> str:
-    parser = ArgumentParser()
-    parser.add_argument(ID_ARGUMENT_NAME, **ID_ARGUMENT_OPTIONS)
-    known_args = parser.parse_known_args()[0]
-    return known_args.id
-
-
-def _password_from_keyring(account_id: str) -> Optional[str]:
-    """ 최초 1회 [system keyring service]에 계정을 등록해야 함.
-
-    등록 방법:
-        코드 사용 (등록 후 제거할 것)
-        > keyring.set_password(`KEYRING_SERVICE_NAME`, 'id', 'password')
-
-        커맨드 라인 사용
-        $ keyring set `KEYRING_SERVICE_NAME` 'id'
-
-    주의:
-        이 작업은 현재 등록하는 계정 정보에 python 접근을 허용함.
-
-    기타:
-        macOS key chain 사용은 macOS 11, python 3.8.7 이상을 필요로 함.
-    """
-    return keyring.get_password(KEYRING_SERVICE_NAME, account_id)

--- a/lotto/site/drivers.py
+++ b/lotto/site/drivers.py
@@ -4,7 +4,8 @@ from selenium import webdriver
 def headless_chrome() -> webdriver:
     options = webdriver.ChromeOptions()
     options.add_argument('--headless')
-    
+    options.add_argument('--window-size=1920,1080')
+
     return chrome(options=options)
 
 

--- a/lotto/site/drivers.py
+++ b/lotto/site/drivers.py
@@ -1,0 +1,12 @@
+from selenium import webdriver
+
+
+def headless_chrome() -> webdriver:
+    options = webdriver.ChromeOptions()
+    options.add_argument('--headless')
+    
+    return chrome(options=options)
+
+
+def chrome(options: webdriver.ChromeOptions = None) -> webdriver:
+    return webdriver.Chrome(options=options)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 testpaths = tests
+markers = buy_required: marks tests as requiring an actual buy (deselect with '-m "not buy"')

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ idna==3.4
 importlib-metadata==6.0.0
 iniconfig==2.0.0
 jaraco.classes==3.2.3
-keyring==23.13.1
 login==0.0.6
 more-itertools==9.0.0
 outcome==1.2.0

--- a/sends/auth.py
+++ b/sends/auth.py
@@ -1,0 +1,51 @@
+import os
+
+from lotto.secret import Secret
+
+
+class Auth:
+
+    def __init__(self, token: str, owner: str, repository: str) -> None:
+        """
+        Parameters:
+            token (str): A token to authenticate on your repository
+            owner (str): The repository owner's username
+            repository (str): The owner and repository name
+
+        Example:
+            token: ghq_nZn7aQ...
+            owner: octocat
+            repository: octocat/Hello-World
+        """
+        self._token = Secret(token)
+        self._owner = owner
+        self._repository = repository
+
+        if not token or not owner or not repository:
+            raise ValueError(f'인증 정보는 필수 값 입니다. {self.__repr__()}')
+
+    @property
+    def token(self):
+        return self._token.value
+
+    @property
+    def owner(self):
+        return self._owner
+
+    @property
+    def repository(self):
+        return self._repository
+
+    def __str__(self) -> str:
+        return f'token={self._token}, owner={self.owner}, repository={self.repository}'
+
+    def __repr__(self) -> str:
+        return f'Auth({self})'
+
+
+def from_env() -> Auth:
+    return Auth(
+        token=os.environ['SEND_GITHUB_TOKEN'],
+        owner=os.environ['SEND_GITHUB_OWNER'],
+        repository=os.environ['SEND_GITHUB_REPOSITORY']
+    )

--- a/sends/github.py
+++ b/sends/github.py
@@ -2,15 +2,14 @@ from typing import Optional, List
 
 import requests
 
-from lotto.secret import Secret
+from sends.auth import Auth
 from sends.send import Send, SendResult, SendError
 
 
-class SendGithubIssue(Send):
+class Issue(Send):
 
-    def __init__(self, token: Secret, repository: str, labels: Optional[List[str]] = None) -> None:
-        self.token = token
-        self.repository = repository
+    def __init__(self, auth: Auth, labels: Optional[List[str]] = None) -> None:
+        self.auth = auth
         self.labels = labels or []
 
     def __call__(self, title: str, content: str) -> SendResult:
@@ -27,10 +26,10 @@ class SendGithubIssue(Send):
         https://docs.github.com/ko/rest/issues/issues?apiVersion=2022-11-28#create-an-issue
         """
         return requests.post(
-            f'https://api.github.com/repos/{self.repository}/issues',
+            f'https://api.github.com/repos/{self.auth.repository}/issues',
             headers={
                 'Accept': 'application/vnd.github+json',
-                'Authorization': f'Bearer {self.token.value}',
+                'Authorization': f'Bearer {self.auth.token}',
                 'X-GitHub-Api-Version': '2022-11-28',
             },
             json={

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -2,17 +2,10 @@ from datetime import date, datetime
 
 import pytest
 import requests
-from selenium import webdriver
 
 import lotto.account
 import sends.auth
-
-
-@pytest.fixture(scope='class')
-def driver():
-    _driver = webdriver.Chrome()
-    yield _driver
-    _driver.quit()
+from lotto.site import drivers
 
 
 @pytest.fixture(scope='session')
@@ -28,6 +21,13 @@ def auth() -> sends.auth.Auth:
 @pytest.fixture(scope='session')
 def labels():
     return ['for-testing']
+
+
+@pytest.fixture(scope='class')
+def driver():
+    _driver = drivers.headless_chrome()
+    yield _driver
+    _driver.quit()
 
 
 def close_testing_issues(auth, labels, since):

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -2,12 +2,10 @@ from datetime import date, datetime
 
 import pytest
 import requests
-from _pytest.config.argparsing import Parser
 from selenium import webdriver
 
 import lotto.account
 import sends.auth
-from lotto.account import ID_ARGUMENT_OPTIONS, ID_ARGUMENT_NAME
 
 
 @pytest.fixture(scope='class')
@@ -25,14 +23,6 @@ def account() -> lotto.account.Account:
 @pytest.fixture(scope='session')
 def auth() -> sends.auth.Auth:
     return sends.auth.from_env()
-
-
-def pytest_addoption(parser):
-    _add_id_option_for_passing_argument_to_pytest(parser)
-
-
-def _add_id_option_for_passing_argument_to_pytest(parser: Parser):
-    parser.addoption(ID_ARGUMENT_NAME, **ID_ARGUMENT_OPTIONS)
 
 
 @pytest.fixture(scope='session')

--- a/tests/functional/test_site.py
+++ b/tests/functional/test_site.py
@@ -11,14 +11,13 @@ def lotto(driver) -> Lotto:
     return Site(driver)
 
 
-# todo: 이거 진짜 돌릴거면 마커 달아놔라
 # noinspection NonAsciiCharacters
 class TestSuccess:
 
-    @pytest.fixture(scope='class', autouse=True)
-    def setup(self, lotto, account):
+    def test_login(self, lotto, account):
         lotto.login(account)
 
+    @pytest.mark.buy_required
     def test_buy(self, lotto):
         구입_매수 = 1
         로또_가격 = 1_000
@@ -27,6 +26,7 @@ class TestSuccess:
 
         assert 결제_금액 == 구입_매수 * 로또_가격
 
+    @pytest.mark.buy_required
     def test_result(self, lotto):
         조회_기간은_오늘 = DateRange(date.today(), date.today())
 

--- a/tests/unit/check_lotto_result/test_check_latest_lotto_result.py
+++ b/tests/unit/check_lotto_result/test_check_latest_lotto_result.py
@@ -18,7 +18,7 @@ def test_last_sunday():
 
 def test_check_latest_lotto_result():
     result = check_latest_lotto_result(
-        account=Account(account_id='stub-id', password='stub-password'),
+        account=Account(id_='stub-id', password='stub-password'),
         lotto=StubLotto(),
         send=StubSend(),
         search_dates=DateRange(date(2023, 2, 12), date(2023, 2, 18))

--- a/tests/unit/lotto/test_account.py
+++ b/tests/unit/lotto/test_account.py
@@ -3,28 +3,32 @@ import pytest
 from lotto.account import Account
 
 
+def _account(id_='user-id', password='abcd1234!@'):
+    return Account(id_=id_, password=password)
+
+
 def test_account():
-    account = Account('user-id', 'abcd1234!@')
+    account = _account('alice1032', 'apple1004!@')
 
-    assert account.id == 'user-id'
-    assert account.password == 'abcd1234!@'
-
-
-def test_raise_when_when_id_empty():
-    with pytest.raises(ValueError, match='아이디와 비밀번호는 필수 값이다'):
-        Account('', 'abcd1234!@')
+    assert account.id == 'alice1032'
+    assert account.password == 'apple1004!@'
 
 
-def test_raise_when_when_password_empty():
-    with pytest.raises(ValueError, match='아이디와 비밀번호는 필수 값이다'):
-        Account('user-id', '')
+def test_raise_when_id_empty():
+    with pytest.raises(ValueError, match='계정 정보는 필수 값 입니다.'):
+        _account(id_='')
+
+
+def test_raise_when_password_empty():
+    with pytest.raises(ValueError, match='계정 정보는 필수 값 입니다.'):
+        _account(password='')
 
 
 def test_masked_password_when_display():
-    account = Account('user-id', 'abcd1234!@')
+    account = _account('simsim2', 'banana1004')
 
-    assert str(account) == 'id=user-id, password=**********'
-    assert repr(account) == 'Account(id=user-id, password=**********)'
+    assert str(account) == 'id=simsim2, password=**********'
+    assert repr(account) == 'Account(id=simsim2, password=**********)'
 
 
 def test_masked_password_when_raises():

--- a/tests/unit/sends/test_auth.py
+++ b/tests/unit/sends/test_auth.py
@@ -1,0 +1,43 @@
+import pytest
+
+from sends.auth import Auth
+
+
+def _auth(token='zbc-bzA2p', owner='octocat', repository='octocat/Hello-World'):
+    return Auth(token=token, owner=owner, repository=repository)
+
+
+def test_auth():
+    auth = _auth(token='Abc-Dz132', owner='squid', repository='squid/Hello-Earth')
+
+    assert auth.token == 'Abc-Dz132'
+    assert auth.owner == 'squid'
+    assert auth.repository == 'squid/Hello-Earth'
+
+
+def test_raise_when_token_empty():
+    with pytest.raises(ValueError, match='인증 정보는 필수 값 입니다.'):
+        _auth(token='')
+
+
+def test_raise_when_owner_empty():
+    with pytest.raises(ValueError, match='인증 정보는 필수 값 입니다.'):
+        _auth(owner='')
+
+
+def test_raise_when_repository_empty():
+    with pytest.raises(ValueError, match='인증 정보는 필수 값 입니다.'):
+        _auth(repository='')
+
+
+def test_masked_token_when_display():
+    auth = _auth(token='abc-M3z', owner='squid', repository='nana/examples')
+
+    assert str(auth) == 'token=*******, owner=squid, repository=nana/examples'
+    assert repr(auth) == 'Auth(token=*******, owner=squid, repository=nana/examples)'
+
+
+def test_masked_token_when_raises():
+    with pytest.raises(ValueError) as err:
+        _auth(owner='', token='abc-de7f')
+    assert 'abc-de7f' not in str(err.value)


### PR DESCRIPTION
## 목표

- git actions를 사용해서 테스트를 자동화한다


## 작업

- 실제 구매가 필요한 테스트는 [pytest mark](https://docs.pytest.org/en/7.1.x/how-to/mark.html)를 사용하여 마킹한다
- 해당 테스트들을 제외한 나머지는 `push`, `pull request` 이벤트 발생 시 자동으로 테스트한다
- 실제 구매가 필요한 테스트는 actions에서 수동으로 실행할 수 있게 한다


## macos runner를 사용한 이유

- `ubuntu`를 사용하면 사이트에서 아래와 같은 예외가 발생하여 `macos`를 사용했다

> 발생 예외
> \- 비정상적인 방법으로 접속하였습니다. 정상적인 PC 환경에서 접속하여 주시기 바랍니다.


## 남은 고민

- [ ] 테스트가 셀레니움을 사용해서 몇 개 없는데도 느리다. 캐싱이란걸 봤는데 적용 가능한지 RABOJA 
- [ ] [dotenv](https://pypi.org/project/python-dotenv/)를 사용해서 로컬에서도 .env를 통해 테스트할 수 있게 할지