### PR TITLE
👷 ci: 테스트용 리파지토리를 설정할 수 있는 옵션을 추가한다

### DIFF
--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -32,7 +32,7 @@ jobs:
           # Github 기본 환경 변수
           SEND_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SEND_GITHUB_OWNER: ${{ github.repository_owner }}
-          SEND_GITHUB_REPOSITORY: ${{ github.repository }}
+          SEND_GITHUB_REPOSITORY: ${{ vars.TESTING_GITHUB_REPOSITORY || github.repository }}
           # 설정이 필요한 환경 변수
           LOTTERY_ACCOUNT_ID: ${{ secrets.LOTTERY_ACCOUNT_ID }}
           LOTTERY_ACCOUNT_PASSWORD: ${{ secrets.LOTTERY_ACCOUNT_PASSWORD }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
           # Github 기본 환경 변수
           SEND_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SEND_GITHUB_OWNER: ${{ github.repository_owner }}
-          SEND_GITHUB_REPOSITORY: ${{ github.repository }}
+          SEND_GITHUB_REPOSITORY: ${{ vars.TESTING_GITHUB_REPOSITORY || github.repository }}
           # 설정이 필요한 환경 변수
           LOTTERY_ACCOUNT_ID: ${{ secrets.LOTTERY_ACCOUNT_ID }}
           LOTTERY_ACCOUNT_PASSWORD: ${{ secrets.LOTTERY_ACCOUNT_PASSWORD }}


### PR DESCRIPTION
## 하고자 한 것

- workflow에서 생성되는 이슈를 다른 repository에 생성하고 싶었음
  - 이력 분리
  - 알람 뮤트


## 하지만 할 수 없는 이유

- `GITHUB_TOKEN`의 권한은 workflow가 포함된 리포지토리로 제한이라 내 소유의 다른 repository에 쓰기 권한이 없다

착각한 게 계속 다른 repository로 테스트를 하고 있어서 당연히 될 줄 알았는데,
로컬에서는 개인 액세스 토큰을 발급받아 사용하고 있던 걸 깜빡함


## 공식 문서 발췌

- `GITHUB_TOKEN`은 **workflow에서 사용하기 위해** 실행 시 자동으로 생성된 토큰이다
- 토큰의 권한은 **workflow가 포함된 리포지토리로 제한**된다
-  토큰 권한 수정은 ...(중략)... 일반적으로 쓰기 권한은 부여할 수 없다
- `GITHUB_TOKEN`으로 사용할 수 없는 권한이 필요한 경우, 개인 액세스 토큰을 만들어라


## 링크

- [About the GITHUB_TOKEN secret](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret)
- [Modifying the permissions for the GITHUB_TOKEN](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token)
- [Granting additional permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#granting-additional-permissions)