### PR TITLE
✨ feat: 직전 회차 조회 기능을 git action로 만든다

### DIFF
--- a/result/action.yml
+++ b/result/action.yml
@@ -5,11 +5,9 @@ inputs:
   id:
     description: '동행복권 계정 아이디'
     required: true
-    default: ${{ secrets.LOTTERY_ACCOUNT_ID}}
   password:
     description: '동행복권 계정 비밀번호'
     required: true
-    default: ${{ secrets.LOTTERY_ACCOUNT_PASSWORD}}
   start-date:
     description: '조회 시작 날짜(YYYY-MM-DD)'
   end-date:

--- a/result/latest/action.yml
+++ b/result/latest/action.yml
@@ -5,11 +5,9 @@ inputs:
   id:
     description: '동행복권 계정 아이디'
     required: true
-    default: ${{ secrets.LOTTERY_ACCOUNT_ID}}
   password:
     description: '동행복권 계정 비밀번호'
     required: true
-    default: ${{ secrets.LOTTERY_ACCOUNT_PASSWORD}}
 
 outputs:
   start-date:

--- a/result/latest/action.yml
+++ b/result/latest/action.yml
@@ -1,0 +1,38 @@
+name: '직전 회차 결과 조회'
+description: '가장 최근 회차의 구매/당첨내역을 조회한다'
+
+inputs:
+  id:
+    description: '동행복권 계정 아이디'
+    required: true
+    default: ${{ secrets.LOTTERY_ACCOUNT_ID}}
+  password:
+    description: '동행복권 계정 비밀번호'
+    required: true
+    default: ${{ secrets.LOTTERY_ACCOUNT_PASSWORD}}
+
+outputs:
+  start-date:
+    description: '조회 시작 날짜(YYYY-MM-DD)'
+    value: ${{ steps.search-latest-result.outputs.start-date }}
+  end-date:
+    description: '조회 종료 날짜(YYYY-MM-DD)'
+    value: ${{ steps.search-latest-result.outputs.end-date }}
+  summary:
+    description: '요약된 조회 결과'
+    value: ${{ steps.search-latest-result.outputs.summary }}
+  table:
+    description: '테이블 형태의 조회 결과'
+    value: ${{ steps.search-latest-result.outputs.table }}
+
+
+runs:
+  using: 'composite'
+  steps:
+    - name: '직전 회차 결괴를 조회한다'
+      id: search-latest-result
+      env:
+        LOTTERY_ACCOUNT_ID: ${{ inputs.id }}
+        LOTTERY_ACCOUNT_PASSWORD: ${{ inputs.password }}
+      shell: bash
+      run: python -m result.latest.main

--- a/result/latest/main.py
+++ b/result/latest/main.py
@@ -1,0 +1,39 @@
+from datetime import date, timedelta
+
+import env
+from lotto.account import Account
+from lotto.lotto import Lotto
+from lotto.site.drivers import headless_chrome
+from lotto.site.site import Site
+from lotto.types import DateRange
+from result.main import result
+
+
+def latest_saturday(today: date) -> date:
+    DAYS_IN_WEEK = 7
+
+    pass_days_in_last_week = len(['일요일', '토요일'])
+    pass_days = (today.weekday() + pass_days_in_last_week) % DAYS_IN_WEEK
+
+    return today - timedelta(days=pass_days)
+
+
+def latest() -> DateRange:
+    SALES_DAYS = 7
+
+    latest_draw_date = latest_saturday(date.today())
+    sales_start_date = latest_draw_date - timedelta(days=SALES_DAYS - 1)
+
+    return DateRange(start=sales_start_date, end=latest_draw_date)
+
+
+def inputs():
+    return env.to_account()
+
+
+def latest_result(lotto: Lotto, account: Account) -> None:
+    result(lotto=lotto, account=account, search_dates=latest())
+
+
+if __name__ == '__main__':
+    latest_result(Site(headless_chrome()), inputs())

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,17 @@
+import pytest
+
+
+@pytest.fixture
+def github_output(tmp_path, monkeypatch):
+    path = tmp_path / "outputs.txt"
+    monkeypatch.setenv('GITHUB_OUTPUT', str(path))
+
+    return path
+
+
+@pytest.fixture
+def github_output_contains(github_output):
+    def contains(expected):
+        return f'{expected}\n' in github_output.read_text()
+
+    return contains

--- a/tests/unit/result/test_latest_result_main.py
+++ b/tests/unit/result/test_latest_result_main.py
@@ -1,0 +1,77 @@
+from datetime import date
+from unittest import mock
+from unittest.mock import ANY
+
+import pytest
+
+from lotto.account import Account
+from lotto.lotto import Lotto
+from lotto.secret import Secret
+from lotto.types import Table
+from result.latest.main import latest_saturday, latest, inputs, latest_result
+
+
+@pytest.fixture
+def github_output(tmp_path, monkeypatch):
+    path = tmp_path / "outputs.txt"
+    monkeypatch.setenv('GITHUB_OUTPUT', str(path))
+
+    return path
+
+
+@pytest.fixture
+def github_output_contains(github_output):
+    def contains(expected):
+        return f'{expected}\n' in github_output.read_text()
+
+    return contains
+
+
+def test_latest_saturday():
+    saturday = date(2022, 12, 31)
+    monday = date(2023, 1, 2)
+
+    assert latest_saturday(today=monday) == saturday
+    assert latest_saturday(today=saturday) == saturday
+
+
+def test_latest():
+    SATURDAY = 5
+    SUNDAY = 6
+
+    sales_start_date, sales_end_date = latest()
+
+    assert sales_start_date.weekday() == SUNDAY
+    assert sales_end_date.weekday() == SATURDAY
+    assert (sales_end_date - sales_start_date).days == 6
+
+
+def test_inputs(monkeypatch):
+    monkeypatch.setenv('LOTTERY_ACCOUNT_ID', '복권 계정 아이디')
+    monkeypatch.setenv('LOTTERY_ACCOUNT_PASSWORD', '복권 계정 비밀번호')
+
+    account = inputs()
+
+    assert account.id == '복권 계정 아이디'
+    assert account.password == '복권 계정 비밀번호'
+
+
+@mock.patch('result.latest.main.result')
+def test_result(mock_result):
+    # given
+    table = Table(headers=[], rows=[[]])
+    account = Account('user-id', Secret('abcde!2@4%'))
+
+    mock_lotto = mock.MagicMock(spec=Lotto)
+    mock_lotto.login.return_value = None
+    mock_lotto.result.return_value = table
+
+    # when
+    latest_result(lotto=mock_lotto, account=account)
+
+    # then
+    mock_result.assert_called_once_with(
+        lotto=ANY,
+        account=account,
+        search_dates=latest()
+    )

--- a/tests/unit/result/test_latest_result_main.py
+++ b/tests/unit/result/test_latest_result_main.py
@@ -2,29 +2,10 @@ from datetime import date
 from unittest import mock
 from unittest.mock import ANY
 
-import pytest
-
 from lotto.account import Account
 from lotto.lotto import Lotto
 from lotto.secret import Secret
-from lotto.types import Table
 from result.latest.main import latest_saturday, latest, inputs, latest_result
-
-
-@pytest.fixture
-def github_output(tmp_path, monkeypatch):
-    path = tmp_path / "outputs.txt"
-    monkeypatch.setenv('GITHUB_OUTPUT', str(path))
-
-    return path
-
-
-@pytest.fixture
-def github_output_contains(github_output):
-    def contains(expected):
-        return f'{expected}\n' in github_output.read_text()
-
-    return contains
 
 
 def test_latest_saturday():
@@ -59,19 +40,15 @@ def test_inputs(monkeypatch):
 @mock.patch('result.latest.main.result')
 def test_result(mock_result):
     # given
-    table = Table(headers=[], rows=[[]])
     account = Account('user-id', Secret('abcde!2@4%'))
-
-    mock_lotto = mock.MagicMock(spec=Lotto)
-    mock_lotto.login.return_value = None
-    mock_lotto.result.return_value = table
+    search_dates_is_latest = latest()
 
     # when
-    latest_result(lotto=mock_lotto, account=account)
+    latest_result(lotto=mock.Mock(spec=Lotto), account=account)
 
     # then
     mock_result.assert_called_once_with(
         lotto=ANY,
         account=account,
-        search_dates=latest()
+        search_dates=search_dates_is_latest
     )

--- a/tests/unit/result/test_result_main.py
+++ b/tests/unit/result/test_result_main.py
@@ -1,8 +1,6 @@
 from datetime import date
 from unittest import mock
 
-import pytest
-
 from lotto.account import Account
 from lotto.lotto import Lotto
 from lotto.secret import Secret
@@ -10,23 +8,7 @@ from lotto.types import DateRange, Table
 from result.main import outputs, result, inputs
 
 
-@pytest.fixture
-def github_output(tmp_path, monkeypatch):
-    path = tmp_path / "outputs.txt"
-    monkeypatch.setenv('GITHUB_OUTPUT', str(path))
-
-    return path
-
-
-@pytest.fixture
-def github_output_contains(github_output):
-    def contains(expected):
-        return f'{expected}\n' in github_output.read_text()
-
-    return contains
-
-
-def test_all_inputs(monkeypatch):
+def test_inputs(monkeypatch):
     monkeypatch.setenv('LOTTERY_ACCOUNT_ID', '복권 계정 아이디')
     monkeypatch.setenv('LOTTERY_ACCOUNT_PASSWORD', '복권 계정 비밀번호')
     monkeypatch.setenv('SEARCH_START_DATE', '2022-12-31')

--- a/tests/unit/result/test_result_main.py
+++ b/tests/unit/result/test_result_main.py
@@ -33,13 +33,13 @@ def test_optional_search_dates_default_is_today(monkeypatch):
 
 
 def test_outputs(github_output_contains):
+    # @formatter:off
     outputs(
         search_dates=DateRange(date(2020, 1, 1), date(2023, 12, 31)),
         table=Table(
-            headers=['구입일자', '복권명', '회차', '선택번호/복권번호',
-                     '구입매수', '당첨결과', '당첨금', '추첨일'],
-            rows=[['2022-12-28', '로또6/45', '1071', '51738 ...',
-                   '3', '미추첨', '-', '2023-01-01']],
+            headers=['구입일자', '복권명', '회차', '선택번호/복권번호', '구입매수', '당첨결과', '당첨금', '추첨일'], # noqa
+            rows=[['2022-12-28', '로또6/45', '1071', '51738 ...', '1', '미추첨', '-', '2023-01-01'], # noqa
+                  ['2022-12-28', '로또6/45', '1071', '11001 ...', '2', '미추첨', '-', '2023-01-01']], # noqa
         )
     )
 
@@ -47,16 +47,19 @@ def test_outputs(github_output_contains):
     assert github_output_contains('end-date=2023-12-31')
     assert github_output_contains(
         "table={'"
-        "headers': ['구입일자', '복권명', '회차', '선택번호/복권번호',"
-        " '구입매수', '당첨결과', '당첨금', '추첨일'], "
-        "'rows': [['2022-12-28', '로또6/45', '1071', '51738 ...',"
-        " '3', '미추첨', '-', '2023-01-01']]}")
+        "headers': ["
+        "'구입일자', '복권명', '회차', '선택번호/복권번호', '구입매수', '당첨결과', '당첨금', '추첨일'"
+        "], "
+        "'rows': ["
+        "['2022-12-28', '로또6/45', '1071', '51738 ...', '1', '미추첨', '-', '2023-01-01'], " # noqa
+        "['2022-12-28', '로또6/45', '1071', '11001 ...', '2', '미추첨', '-', '2023-01-01']" # noqa
+        "]}")
     assert github_output_contains(
         "summary=["
-        "{'round': '1071회', 'draw_date': '2023-01-01',"
-        " 'prize': '0원', 'quantity': '3장'}"
+        "{'round': '1071회', 'draw_date': '2023-01-01', 'prize': '0원', 'quantity': '3장'}" # noqa
         "]"
     )
+    # @formatter:on
 
 
 @mock.patch('result.main.outputs')

--- a/tests/unit/sends/test_github_main.py
+++ b/tests/unit/sends/test_github_main.py
@@ -1,29 +1,11 @@
 from unittest import mock
 
-import pytest
-
 from lotto.secret import Secret
 from sends.github.issue import Issue
 from sends.github.main import inputs, outputs, send
 
 
-@pytest.fixture
-def github_output(tmp_path, monkeypatch):
-    path = tmp_path / "outputs.txt"
-    monkeypatch.setenv('GITHUB_OUTPUT', str(path))
-
-    return path
-
-
-@pytest.fixture
-def github_output_contains(github_output):
-    def contains(expected):
-        return f'{expected}\n' in github_output.read_text()
-
-    return contains
-
-
-def test_all_inputs(monkeypatch):
+def test_inputs(monkeypatch):
     monkeypatch.setenv('ISSUE_TOKEN', '토큰')
     monkeypatch.setenv('ISSUE_REPOSITORY', '리포')
     monkeypatch.setenv('ISSUE_TITLE', '타이틀')


### PR DESCRIPTION
## 이 작업으로 변경된 것

### git action inputs에서 default 제거

> With the exception of GITHUB_TOKEN, secrets are not passed to the runner when a workflow is triggered from a forked repository.

- [공식문서](https://docs.github.com/en/actions/security-guides/encrypted-secrets#using-encrypted-secrets-in-a-workflow)를 보면 위와같이 fork repository의 runner에게는 `secrets`이 전달되지 않는다고 나와있다
  - (GITHUB_TOKEN 제외)
- 그래서 해당 `secrets`를 사용하여 `default`를 주게되면 아래와 같은 에러가 발생한다
  - `Unrecognized named-value: 'secrets' `
- 해결 방법은 그냥 사용 측에서 직접 지정하면 됨 

### `@formatter:off`
- 현재 프로젝트 자동 줄바꿈 너비를 79로 해놨는데 dict 형태의 테스트 데이터는 오히려 눈에 덜 들어오는 것 같아 이 옵션을 사용하여 제외하였다
- [설정 방법.velog(IntelliJ로 작성됐지만 Pycharm도 동일)](https://velog.io/@viiviii/IntelliJ-자동-정렬-시-code-fragments-제외-설정하기)
- [Pycharm Exclude code fragments from reformatting in the editor.docs](https://www.jetbrains.com/help/pycharm/reformat-and-rearrange-code.html#exclude_part_of_code)

## 해야할 일

이 PR을 생성하고 merge 하려는데 보니까 Tests without buys 스텝이 10분동안 돌아가고 있음

- [ ] 이를 해결하고
- [ ] 관련 설정이 있는지 찾아서 보강할 것