### PR TITLE
:sparkles: feat: Table output 형식을 마크다운으로 반환한다

### DIFF
--- a/result/main.py
+++ b/result/main.py
@@ -1,6 +1,8 @@
 import os
+import secrets
 from dataclasses import asdict
 from datetime import date, timedelta
+from typing import IO
 
 import env
 from lotto.account import Account
@@ -8,6 +10,7 @@ from lotto.lotto import Lotto
 from lotto.site.drivers import headless_chrome
 from lotto.site.site import Site
 from lotto.types import DateRange, Table
+from result import markdown
 from result.summary import Summary
 
 
@@ -38,7 +41,15 @@ def outputs(search_dates: DateRange, table: Table) -> None:
         print(f'start-date={search_dates.start}', file=fh)
         print(f'end-date={search_dates.end}', file=fh)
         print(f'summary={asdict(Summary.from_table(table))}', file=fh)
-        print(f'table={asdict(table)}', file=fh)
+        _output_multiline_value('table', markdown.from_table(table), file=fh)
+
+
+def _output_multiline_value(name: str, value: str, file: IO[str]) -> None:
+    delimiter = secrets.token_hex(8)
+
+    print(f'{name}<<{delimiter}', file=file)
+    print(value, file=file)
+    print(delimiter, file=file)
 
 
 def latest_result(lotto: Lotto, account: Account) -> None:

--- a/result/markdown.py
+++ b/result/markdown.py
@@ -1,0 +1,8 @@
+from lotto.types import Table
+
+
+def from_table(table: Table) -> str:
+    headers = '|'.join(table.headers)
+    separator = '|'.join([':---:' for _ in table.headers])
+    rows = '\n'.join(['|'.join(row) for row in table.rows])
+    return f'{headers}\n{separator}\n{rows}\n'

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -15,3 +15,12 @@ def github_output_contains(github_output):
         return f'{expected}\n' in github_output.read_text()
 
     return contains
+
+
+@pytest.fixture
+def assert_contains_multiline_github_output(github_output):
+    def assertions(name, value):
+        assert f'{name}<<' in github_output.read_text()
+        assert value in github_output.read_text()
+
+    return assertions

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -10,17 +10,17 @@ def github_output(tmp_path, monkeypatch):
 
 
 @pytest.fixture
-def github_output_contains(github_output):
-    def contains(expected):
-        return f'{expected}\n' in github_output.read_text()
+def assert_contains_github_output(github_output):
+    def assertion(name, value):
+        assert f'{name}={value}\n' in github_output.read_text()
 
-    return contains
+    return assertion
 
 
 @pytest.fixture
 def assert_contains_multiline_github_output(github_output):
-    def assertions(name, value):
+    def assertion(name, value):
         assert f'{name}<<' in github_output.read_text()
         assert value in github_output.read_text()
 
-    return assertions
+    return assertion

--- a/tests/unit/result/test_markdown.py
+++ b/tests/unit/result/test_markdown.py
@@ -1,0 +1,19 @@
+from lotto.types import Table
+from result import markdown
+
+
+def test_markdown_from_table():
+    table = Table(
+        headers=['복권명', '당첨금'],
+        rows=[['스피또', '100원'],
+              ['스피또', '999원']],
+    )
+
+    actual = markdown.from_table(table)
+
+    assert actual == (
+        '복권명|당첨금\n'
+        ':---:|:---:\n'
+        '스피또|100원\n'
+        '스피또|999원\n'
+    )

--- a/tests/unit/result/test_result_main.py
+++ b/tests/unit/result/test_result_main.py
@@ -1,5 +1,4 @@
 from datetime import date
-from textwrap import dedent
 from unittest import mock
 
 import pytest
@@ -58,28 +57,29 @@ def outputs():
     return builder
 
 
-def test_output_dates(outputs, github_output_contains):
+def test_output_dates(outputs, assert_contains_github_output):
     outputs(search_dates=DateRange(
         start=date(2020, 1, 1),
         end=date(2023, 12, 31)
     ))
 
-    assert github_output_contains('start-date=2020-01-01')
-    assert github_output_contains('end-date=2023-12-31')
+    assert_contains_github_output(name='start-date', value='2020-01-01')
+    assert_contains_github_output(name='end-date', value='2023-12-31')
 
 
-def test_output_summary(outputs, github_output_contains):
+def test_output_summary(outputs, assert_contains_github_output):
     outputs(
-        header=['복권명', '회차', '추첨일', '구입매수', '당첨금'],
-        rows=[['로또6/45', '1071', '2023-01-01', '2', '-'],
-              ['로또6/45', '1071', '2023-01-01', '3', '-']]
+        header=['복권명', '회차', '추첨일', '당첨금', '구입매수'],
+        rows=[['로또6/45', '1071', '2023-01-01', '-', '2'],
+              ['로또6/45', '1071', '2023-01-01', '-', '3']]
     )
 
-    assert github_output_contains(
-        "summary={"
-        "'name': '로또6/45', 'round': '1071회', 'draw_date': '2023-01-01',"
-        " 'prize': '0원', 'quantity': '5장'"
-        "}"
+    assert_contains_github_output(
+        name="summary",
+        value="{"
+              "'name': '로또6/45', 'round': '1071회', 'draw_date': '2023-01-01',"
+              " 'prize': '0원', 'quantity': '5장'"
+              "}"
     )
 
 
@@ -89,17 +89,14 @@ def test_output_table(outputs, assert_contains_multiline_github_output):
         header=['구입일자', '복권명', '회차', '선택번호/복권번호', '구입매수', '당첨결과', '당첨금', '추첨일'],  # noqa
         rows=[['2022-12-28', '로또6/45', '1071', '00000', '2', '미추첨', '-', '2023-01-01']] # noqa
     )
+    # @formatter:on
 
     assert_contains_multiline_github_output(
         name='table',
-        value=dedent("""
-        구입일자|복권명|회차|선택번호/복권번호|구입매수|당첨결과|당첨금|추첨일
-        :---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:
-        2022-12-28|로또6/45|1071|00000|2|미추첨|-|2023-01-01
-        """)
-
+        value=('구입일자|복권명|회차|선택번호/복권번호|구입매수|당첨결과|당첨금|추첨일\n'
+               ':---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:\n'
+               '2022-12-28|로또6/45|1071|00000|2|미추첨|-|2023-01-01\n')
     )
-    # @formatter:on
 
 
 @mock.patch('result.main.outputs')

--- a/tests/unit/result/test_result_main.py
+++ b/tests/unit/result/test_result_main.py
@@ -1,4 +1,5 @@
 from datetime import date
+from textwrap import dedent
 from unittest import mock
 
 import pytest
@@ -82,21 +83,21 @@ def test_output_summary(outputs, github_output_contains):
     )
 
 
-def test_output_table(outputs, github_output_contains):
+def test_output_table(outputs, assert_contains_multiline_github_output):
     # @formatter:off
     outputs(
         header=['구입일자', '복권명', '회차', '선택번호/복권번호', '구입매수', '당첨결과', '당첨금', '추첨일'],  # noqa
-        rows=[['2022-12-28', '로또6/45', '1071', '51738 ...', '2', '미추첨', '-', '2023-01-01']] # noqa
+        rows=[['2022-12-28', '로또6/45', '1071', '00000', '2', '미추첨', '-', '2023-01-01']] # noqa
     )
 
-    assert github_output_contains(
-        "table={'"
-        "headers': ["
-        "'구입일자', '복권명', '회차', '선택번호/복권번호', '구입매수', '당첨결과', '당첨금', '추첨일'"
-        "], "
-        "'rows': ["
-        "['2022-12-28', '로또6/45', '1071', '51738 ...', '2', '미추첨', '-', '2023-01-01']" # noqa
-        "]}"
+    assert_contains_multiline_github_output(
+        name='table',
+        value=dedent("""
+        구입일자|복권명|회차|선택번호/복권번호|구입매수|당첨결과|당첨금|추첨일
+        :---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:
+        2022-12-28|로또6/45|1071|00000|2|미추첨|-|2023-01-01
+        """)
+
     )
     # @formatter:on
 

--- a/tests/unit/sends/test_github_main.py
+++ b/tests/unit/sends/test_github_main.py
@@ -32,10 +32,10 @@ def test_label_is_optional_input(monkeypatch):
     assert not actual.label
 
 
-def test_outputs(github_output_contains):
+def test_outputs(assert_contains_github_output):
     outputs({'number': '679231'})
 
-    assert github_output_contains('number=679231')
+    assert_contains_github_output(name='number', value='679231')
 
 
 @mock.patch('sends.github.main.create')


### PR DESCRIPTION
## 이 작업에서 변경된 것

- Table 데이터를 배열 형식의 `header`, `row`로 반환했는데 `markdown`으로 반환하여 보기 편하게 개선

## 변경 후 사용

상세 내용이 보고 싶은 경우 table markdown을 사용할 수 있다

<img width="918" alt="image" src="https://user-images.githubusercontent.com/75404713/227497945-450ee94b-991d-4f68-a28a-ced39efb9e0c.png">

