### PR TITLE
✨ feat: 로또 구매 workflow를 만든다

### DIFF
--- a/.github/workflows/purchase.yml
+++ b/.github/workflows/purchase.yml
@@ -1,0 +1,48 @@
+name: '로또 복권 구매'
+
+on:
+  workflow_call:
+    # input
+    secrets:
+      id:
+        description: '동행복권 계정 아이디'
+        required: true
+      password:
+        description: '동행복권 계정 비밀번호'
+        required: true
+    inputs:
+      amount:
+        description: '복권 구매 수량'
+        default: 1
+        required: false
+        type: number
+    # output
+    outputs:
+      total-price:
+        description: '총 구매 금액'
+        value: ${{ jobs.purchase.outputs.total-price }}
+
+
+jobs:
+  purchase:
+    name: '로또 복권 구매'
+    runs-on: macos-latest
+    outputs:
+      total-price: ${{ steps.result.outputs.total-price }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          repository: viiviii/jubilant-train
+          ref: main # todo: 태그나 SHA 키로 변경
+
+      - name: Setup
+        uses: ./setup
+
+      - name: Purchase lottery
+        id: result
+        env:
+          LOTTERY_ACCOUNT_ID: ${{ secrets.id }}
+          LOTTERY_ACCOUNT_PASSWORD: ${{ secrets.password }}
+          LOTTERY_AMOUNT: ${{ inputs.amount }}
+        run: python -m purchase.main

--- a/purchase/main.py
+++ b/purchase/main.py
@@ -1,0 +1,27 @@
+import os
+
+import env
+from lotto.account import Account
+from lotto.lotto import Lotto
+from lotto.site.drivers import headless_chrome
+from lotto.site.site import Site
+
+
+def inputs():
+    return env.to_account(), int(os.getenv("LOTTERY_AMOUNT") or "1")
+
+
+def outputs(total_price: int) -> None:
+    with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+        print(f'total-price={"{:,.0f}원".format(total_price)}', file=fh)
+
+
+def buy(lotto: Lotto, account: Account, amount: int) -> None:
+    lotto.login(account)
+    result = lotto.buy(amount=amount)
+
+    outputs(total_price=result)
+
+
+if __name__ == '__main__':
+    buy(Site(headless_chrome()), *inputs())

--- a/tests/unit/purchase/test_purchase_main.py
+++ b/tests/unit/purchase/test_purchase_main.py
@@ -1,0 +1,46 @@
+from unittest import mock
+
+from lotto.account import Account
+from lotto.lotto import Lotto
+from lotto.secret import Secret
+from purchase import main
+from purchase.main import inputs
+
+
+def test_inputs(monkeypatch):
+    monkeypatch.setenv('LOTTERY_ACCOUNT_ID', '복권 계정 아이디')
+    monkeypatch.setenv('LOTTERY_ACCOUNT_PASSWORD', '복권 계정 비밀번호')
+    monkeypatch.setenv('LOTTERY_AMOUNT', '2')
+
+    account, amount = inputs()
+
+    assert account.id == '복권 계정 아이디'
+    assert account.password == '복권 계정 비밀번호'
+    assert amount == 2
+
+
+def test_outputs(assert_contains_github_output):
+    main.outputs(total_price=3000)
+
+    assert_contains_github_output(
+        name="total-price",
+        value="3,000원"
+    )
+
+
+@mock.patch('purchase.main.outputs')
+def test_buy(mock_main_outputs):
+    # given
+    account = Account('user-id', Secret('abcde!2@4%'))
+
+    mock_lotto = mock.MagicMock(spec=Lotto)
+    mock_lotto.buy.return_value = 3000
+
+    # when
+    main.buy(lotto=mock_lotto, account=account, amount=3)
+
+    # then
+    mock_lotto.login.assert_called_once_with(account)
+    mock_lotto.buy.assert_called_once_with(amount=3)
+
+    mock_main_outputs.assert_called_once_with(total_price=3000)


### PR DESCRIPTION
closes #73 


## 메모

- 생각해보니 reusable workflow에서 caller의 컨텍스트를 받아 사용해야될 것 같은데
  -  i.e. 해당 caller가 v1을 사용했다면 checkout 받는 코드도 v1을 사용
- 근데 reusable workflow에선 caller의 컨텍스트에 접근할 수 없다
  - 그래서 현재 v1로 workflow를 사용해도 실제론 최신 main 코드를 사용함 
  - 다른 워크플로우에선 잘 됐는데?
- 찾아보니 아직 업데이트가 안됐거나 음...내부 사정이 있는 듯?
  - [make reference accessible in reusable workflow](https://www.github.com/actions/toolkit/issues/1264)